### PR TITLE
Convert to slash commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 Cargo.lock
 /.vscode
 config.json
-*.sqlite
+*.sqlite*

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,21 @@ edition = "2021"
 
 [dependencies]
 tokio = {version = "1.20", features = ["macros", "rt-multi-thread"]}
-serenity = { default-features = false, features = ["client","gateway","model","rustls_backend", "framework", "standard_framework", "builder", "http", "utils", "collector", "unstable_discord_api"], version = "0.11" }
+serenity = { default-features = false, features = [
+    "cache",
+    "client",
+    "gateway",
+    "model",
+    "time",
+    "rustls_backend", 
+    "framework", 
+    "standard_framework", 
+    "builder", 
+    "http", 
+    "utils", 
+    "collector", 
+    "unstable_discord_api",
+    ], version = "0.11" }
 lazy_static = "1.4"
 regex = "1.6"
 rand = "0.8"

--- a/README.md
+++ b/README.md
@@ -14,10 +14,18 @@ This is a discord bot intended to assist with using Discord as a forum to play p
 
 ## Game specific commands
 ### Cyberpunk 2020
+#### Prefix commands
 * !cp_init - Roll initiative. If you have an active tracked character, apply initiative score and combat sense if applicable.
 * !cp_skill <skillname> - Make a skill roll. If you have an active tracked character, and specify a skill, the appropriate attribute and skill rank are applied.
 * !cp_pick_char <character> - If character is unspecified, it will show a list of your characters which are currently being tracked. If character name (or number from the displayed list) is specified, set that character as your active character.
 * !cp_add_char - Add a tracked character. Not yet fully implemented.
+
+#### slash commands
+* /add - Equivalent to !cp_add_char above.
+* /init - Equivalent to !cp_init above.
+* /pick_char - Equivalent to !cp_pick_char above.
+* /skill - Equivalent to !cp_skill above.
+
 
 ## Current status
 * Bot can connect to server and listen for commands. 
@@ -28,6 +36,7 @@ This is a discord bot intended to assist with using Discord as a forum to play p
 
 
 ## Immediate development goals:
-* Look into replacing serenity::framework with something like poise, to facilitate using slash commands instead of prefix commands. 
+* Remove the prefix commands which have slash command equivalents.
+* Look into converting the game-specific slash commands to sub-commands of a game-specific command (i.e. instead of /add something like /cp2020 add)
 * Need to implement adding a character to the bot.
-* Need to implement updating a tracked character.
+* Need to implement editing a tracked character.

--- a/config.template.json
+++ b/config.template.json
@@ -1,5 +1,6 @@
 { 
     "token": "<token goes here or 'ENV' to get token from environment variable>",
     "prefix": "!",
-    "db_url": "<location of SQLite database goes here>"
+    "db_url": "<location of SQLite database goes here>",
+    "command_guilds": ["list of guild ID's to register slash commands with."]
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,7 @@ pub mod config {
         token: Option<String>,
         prefix: Option<String>,
         db_url: Option<String>,
+        command_guilds: Option<Vec<String>>,
     }
 
     impl Config {
@@ -13,6 +14,7 @@ pub mod config {
                 token: None,
                 prefix: Some("!".to_string()),
                 db_url: None,
+                command_guilds: None,
             };
         }
 
@@ -53,6 +55,13 @@ pub mod config {
             }
         }
 
+        pub fn get_command_guilds(self: &Self) -> Vec<String> {
+            match &self.command_guilds {
+                Some(g) => return g.clone(),
+                None => return vec![],
+            };
+        }
+
         //set config values
         pub fn set_token(&mut self, token: &str) {
             self.token = Some(token.to_string());
@@ -65,5 +74,10 @@ pub mod config {
         pub fn set_db_url(&mut self, db: &str) {
             self.db_url = Some(db.to_string());
         }
+
+        pub fn set_command_guilds(&mut self, guilds: Vec<String>) {
+            self.command_guilds = Some(guilds);
+        }
+
     }
 }

--- a/src/cp2020/add.rs
+++ b/src/cp2020/add.rs
@@ -9,6 +9,6 @@ pub fn register(command: &mut CreateApplicationCommand) -> &mut CreateApplicatio
     command.name("add").description("Add a character")
 }
 
-pub async fn run(interaction: Interaction, ctx: &Context) {
+pub async fn run(interaction: &Interaction, ctx: &Context) {
     //code to add a character will go here.
 }

--- a/src/cp2020/add.rs
+++ b/src/cp2020/add.rs
@@ -1,0 +1,14 @@
+use serenity::{
+    builder::CreateApplicationCommand, model::prelude::application::interaction::Interaction,
+    prelude::*,
+};
+
+use crate::cp2020::common::*;
+
+pub fn register(command: &mut CreateApplicationCommand) -> &mut CreateApplicationCommand {
+    command.name("add").description("Add a character")
+}
+
+pub async fn run(interaction: Interaction, ctx: &Context) {
+    //code to add a character will go here.
+}

--- a/src/cp2020/common.rs
+++ b/src/cp2020/common.rs
@@ -1,0 +1,217 @@
+use rand::Rng;
+use sqlx::Row;
+
+use crate::dbinterface::DB_POOL;
+
+pub struct Cp2020Skill {
+    pub skill_name: String,
+    pub skill_attribute: String,
+    pub skill_value: u8,
+}
+
+pub struct Cp2020Character {
+    pub id: i64,
+    pub character_name: String,
+    pub role: String,
+    pub inteligence: u8,
+    pub reflex: u8,
+    pub initiative: u8,
+    pub tech: u8,
+    pub cool: u8,
+    pub attractiveness: u8,
+    pub movement: u8,
+    pub body: u8,
+    pub empathy: u8,
+    pub special_ability: u8,
+    pub skills: Vec<Cp2020Skill>,
+}
+
+// async fn add_character(interaction: Interaction, ctx: &Context) {
+//     let modal = interaction.application_command().unwrap()
+//     .create_interaction_response(&ctx.http, |resp| {
+//         resp.kind(InteractionResponseType::Modal)
+//             .interaction_response_data(|response| {
+//                 response.custom_id("add_character");
+//                 response.title("");
+//                 response.components(|a_rows| {
+//                     a_rows.create_action_row(|row| {
+//                         row.create_input_text(|input| {
+//                             input.custom_id("cname")
+//                             .style(InputTextStyle::Short)
+//                             .label("Name")
+//                             .required(true)
+//                         })
+//                     })
+//                 })
+//             })
+//     }).await;
+// }
+
+pub async fn get_active_character(serverid: &str, userid: &str) -> Option<i64> {
+    if let Some(db) = DB_POOL.get() {
+        let sql = "SELECT character_id FROM active_characters WHERE server_id = ? AND user_id = ?";
+        if let Ok(row) = sqlx::query(sql)
+            .bind(serverid)
+            .bind(userid)
+            .fetch_one(db)
+            .await
+        {
+            if let Ok(r) = row.try_get("character_id") {
+                return Some(r);
+            }
+        }
+    }
+    None
+}
+
+async fn set_active_character(serverid: &str, userid: &str, characterid: i64) -> bool {
+    if let Some(db) = DB_POOL.get() {
+        let sql_del = "DELETE FROM active_characters WHERE server_id = ? AND user_id = ?";
+        let sql_ins =
+            "INSERT INTO active_characters (server_id, user_id, character_id) VALUES (?, ?, ?)";
+        _ = sqlx::query(sql_del)
+            .bind(serverid)
+            .bind(userid)
+            .execute(db)
+            .await;
+        let ret = sqlx::query(sql_ins)
+            .bind(serverid)
+            .bind(userid)
+            .bind(characterid)
+            .execute(db)
+            .await;
+        return ret.is_ok();
+    }
+    false
+}
+
+async fn get_character_list(serverid: &str, userid: &str) -> Vec<Cp2020Character> {
+    let mut characters: Vec<Cp2020Character> = vec![];
+    if let Some(db) = DB_POOL.get() {
+        let sql = "SELECT id, character_name, role FROM cp2020.characters WHERE server_id = ? AND user_id = ? ORDER BY id ASC";
+        let mut rows = sqlx::query(sql).bind(serverid).bind(userid).fetch(db);
+        while let Ok(Some(chr)) = serenity::futures::TryStreamExt::try_next(&mut rows).await {
+            let skills = get_skills(chr.get("id")).await;
+            characters.push(Cp2020Character {
+                id: chr.get("id"),
+                character_name: chr.get("character_name"),
+                role: chr.get("role"),
+                inteligence: chr.get("inteligence"),
+                reflex: chr.get("reflex"),
+                initiative: chr.get("initiative"),
+                tech: chr.get("tech"),
+                cool: chr.get("cool"),
+                attractiveness: chr.get("attractiveness"),
+                movement: chr.get("movement"),
+                body: chr.get("body"),
+                empathy: chr.get("empathy"),
+                special_ability: chr.get("special_ability"),
+                skills: skills,
+            });
+        }
+    }
+    characters
+}
+
+pub fn d10_exploding() -> u32 {
+    let mut total: u32 = 0;
+    let mut done: bool = false;
+    while !done {
+        let d: u32 = rand::thread_rng().gen_range(1..=10);
+        done = d != 10;
+        total += d;
+    }
+    total
+}
+
+pub async fn get_character(characterid: i64) -> Option<Cp2020Character> {
+    if let Some(db) = DB_POOL.get() {
+        let character_qry = "SELECT id, server_id, user_id, role, inteligence, reflex, initiative, tech, cool, attractiveness, movement, body, empathy, special_ability 
+                             FROM cp2020.characters
+                             WHERE character_id = ?";
+        let mut character = sqlx::query(character_qry).bind(characterid).fetch(db);
+        if let Ok(Some(chr)) = serenity::futures::TryStreamExt::try_next(&mut character).await {
+            let skills = get_skills(characterid).await;
+            return Some(Cp2020Character {
+                id: chr.get("id"),
+                character_name: chr.get("character_name"),
+                role: chr.get("role"),
+                inteligence: chr.get("inteligence"),
+                reflex: chr.get("reflex"),
+                initiative: chr.get("initiative"),
+                tech: chr.get("tech"),
+                cool: chr.get("cool"),
+                attractiveness: chr.get("attractiveness"),
+                movement: chr.get("movement"),
+                body: chr.get("body"),
+                empathy: chr.get("empathy"),
+                special_ability: chr.get("special_ability"),
+                skills: skills,
+            });
+        }
+    }
+    None
+}
+
+async fn get_skills(characterid: i64) -> Vec<Cp2020Skill> {
+    let mut skills: Vec<Cp2020Skill> = vec![];
+    if let Some(db) = DB_POOL.get() {
+        let skills_qry = "SELECT skill_name, skill_attribute, skill_value
+                FROM cp2020.skills
+                WHERE character_id = ?";
+        let mut skill_rows = sqlx::query(skills_qry).bind(characterid).fetch(db);
+        while let Ok(Some(r)) = serenity::futures::TryStreamExt::try_next(&mut skill_rows).await {
+            skills.push(Cp2020Skill {
+                skill_attribute: r.get("skill_attribute"),
+                skill_name: r.get("skill_name"),
+                skill_value: r.get("skill_value"),
+            });
+        }
+    }
+    skills
+}
+
+pub async fn cp2020_init() {
+    if let Some(db) = DB_POOL.get() {
+        let character_table = "CREATE TABLE IF NOT EXISTS cp2020.characters (
+                        id INTEGER primary key AUTOINCREMENT,
+                        server_id TEXT NOT NULL,
+                        user_id TEXT NOT NULL,
+                        character_name TEXT NOT NULL,
+                        role TEXT NOT NULL,
+                        inteligence INTEGER NOT NULL,
+                        reflex INTEGER NOT NULL,
+                        initiative INTEGER NOT NULL,
+                        tech INTEGER NOT NULL,
+                        cool INTEGER NOT NULL,
+                        attractiveness INTEGER NOT NULL,
+                        movement INTEGER NOT NULL,
+                        body INTEGER NOT NULL,
+                        empathy INTEGER NOT NULL,
+                        special_ability INTEGER NOT NULL
+                    )";
+        let character_index = "CREATE INDEX IF NOT EXISTS cp2020.character_user_server_channel ON cp2020.characters (server_id, user_id)";
+        let skill_table = "CREATE TABLE IF NOT EXISTS cp2020.skills (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        character_id INTEGER NOT NULL REFERENCES cp2020.characters (id) ON DELETE CASCADE ON UPDATE CASCADE,
+                        skill_name TEXT NOT NULL,
+                        skill_attribute TEXT NOT NULL,
+                        skill_value INTEGER NOT NULL
+                    )";
+        let skill_index =
+            "CREATE INDEX IF NOT EXISTS cp2020.skill_character_id ON cp2020.skills (character_id)";
+        let active_character_table = "CREATE TABLE IF NOT EXISTS cp2020.active_characters (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        user_id TEXT NOT NULL,
+                        server_id TEXT NOT NULL,
+                        character_id INTEGER NOT NULL REFERENCES cp2020.characters (id) ON DELETE CASCADE ON UPDATE CASCADE
+            )";
+        let active_character_index = "CREATE UNIQUE INDEX IF NOT EXISTS cp2020.active_character_unique_server_user ON cp2020.active_characters (server_id, user_id)";
+        _ = sqlx::query(character_table).execute(db).await;
+        _ = sqlx::query(character_index).execute(db).await;
+        _ = sqlx::query(skill_table).execute(db).await;
+        _ = sqlx::query(skill_index).execute(db).await;
+        _ = sqlx::query(active_character_table).execute(db).await;
+        _ = sqlx::query(active_character_index).execute(db).await;
+    }
+}

--- a/src/cp2020/common.rs
+++ b/src/cp2020/common.rs
@@ -1,4 +1,5 @@
 use rand::Rng;
+use serenity::model::application::command::Command;
 use sqlx::Row;
 
 use crate::dbinterface::DB_POOL;
@@ -26,27 +27,6 @@ pub struct Cp2020Character {
     pub skills: Vec<Cp2020Skill>,
 }
 
-// async fn add_character(interaction: Interaction, ctx: &Context) {
-//     let modal = interaction.application_command().unwrap()
-//     .create_interaction_response(&ctx.http, |resp| {
-//         resp.kind(InteractionResponseType::Modal)
-//             .interaction_response_data(|response| {
-//                 response.custom_id("add_character");
-//                 response.title("");
-//                 response.components(|a_rows| {
-//                     a_rows.create_action_row(|row| {
-//                         row.create_input_text(|input| {
-//                             input.custom_id("cname")
-//                             .style(InputTextStyle::Short)
-//                             .label("Name")
-//                             .required(true)
-//                         })
-//                     })
-//                 })
-//             })
-//     }).await;
-// }
-
 pub async fn get_active_character(serverid: &str, userid: &str) -> Option<i64> {
     if let Some(db) = DB_POOL.get() {
         let sql = "SELECT character_id FROM active_characters WHERE server_id = ? AND user_id = ?";
@@ -64,7 +44,7 @@ pub async fn get_active_character(serverid: &str, userid: &str) -> Option<i64> {
     None
 }
 
-async fn set_active_character(serverid: &str, userid: &str, characterid: i64) -> bool {
+pub async fn set_active_character(serverid: &str, userid: &str, characterid: i64) -> bool {
     if let Some(db) = DB_POOL.get() {
         let sql_del = "DELETE FROM active_characters WHERE server_id = ? AND user_id = ?";
         let sql_ins =
@@ -85,7 +65,7 @@ async fn set_active_character(serverid: &str, userid: &str, characterid: i64) ->
     false
 }
 
-async fn get_character_list(serverid: &str, userid: &str) -> Vec<Cp2020Character> {
+pub async fn get_character_list(serverid: &str, userid: &str) -> Vec<Cp2020Character> {
     let mut characters: Vec<Cp2020Character> = vec![];
     if let Some(db) = DB_POOL.get() {
         let sql = "SELECT id, character_name, role FROM cp2020.characters WHERE server_id = ? AND user_id = ? ORDER BY id ASC";

--- a/src/cp2020/init.rs
+++ b/src/cp2020/init.rs
@@ -1,10 +1,5 @@
 use serenity::{
-    builder::CreateApplicationCommand,
-    model::{
-        prelude::{
-            application::interaction::{Interaction},
-        },
-    },
+    builder::CreateApplicationCommand, model::prelude::application::interaction::Interaction,
     prelude::*,
 };
 

--- a/src/cp2020/init.rs
+++ b/src/cp2020/init.rs
@@ -1,0 +1,48 @@
+use serenity::{
+    builder::CreateApplicationCommand,
+    model::{
+        prelude::{
+            application::interaction::{Interaction},
+        },
+    },
+    prelude::*,
+};
+
+use crate::cp2020::common::*;
+
+pub fn register(command: &mut CreateApplicationCommand) -> &mut CreateApplicationCommand {
+    command.name("init").description("Roll initiative")
+}
+
+pub async fn run(interaction: Interaction, ctx: &Context) {
+    if let Some(app) = interaction.application_command() {
+        let serverid = format!("{}", app.guild_id.unwrap_or_default().0);
+        let userid = format!("{}", app.user.id.0);
+        let mut modifier: u32 = 0;
+        let mut response: String = String::from("");
+        if let Some(cid) = get_active_character(&serverid, &userid).await {
+            if let Some(character) = get_character(cid).await {
+                modifier += character.initiative as u32;
+                if character.role.to_lowercase() == "solo" {
+                    modifier += character.special_ability as u32;
+                }
+            } else {
+                response += "__***Active character could not be loaded!***__\n"
+            }
+        } else {
+            response += "*No active character.*\n"
+        };
+
+        let result = d10_exploding();
+        response = format!(
+            "{}{} rolled for initiative and got:\n {}",
+            response,
+            app.user.name,
+            result + modifier
+        );
+
+        if let Err(why) = app.channel_id.say(&ctx.http, response).await {
+            println!("Error sending message: {:?}", why);
+        }
+    }
+}

--- a/src/cp2020/mod.rs
+++ b/src/cp2020/mod.rs
@@ -1,0 +1,3 @@
+pub mod common;
+pub mod init;
+pub mod skill;

--- a/src/cp2020/mod.rs
+++ b/src/cp2020/mod.rs
@@ -1,3 +1,5 @@
+pub mod add;
 pub mod common;
 pub mod init;
+pub mod pick_char;
 pub mod skill;

--- a/src/cp2020/pick_char.rs
+++ b/src/cp2020/pick_char.rs
@@ -1,0 +1,76 @@
+use std::sync::Arc;
+
+use serenity::{
+    builder::CreateApplicationCommand, model::prelude::application::interaction::Interaction,
+    prelude::*,
+};
+
+use crate::cp2020::common::*;
+
+pub fn register(command: &mut CreateApplicationCommand) -> &mut CreateApplicationCommand {
+    command
+        .name("pick_char")
+        .description("Add a character")
+        .create_option(|option| {
+            option
+                .name("character")
+                .description("name or number of character to select")
+                .required(false)
+        })
+}
+
+pub async fn run(interaction: Interaction, ctx: &Context) {
+    if let Some(app) = interaction.application_command() {
+        let serverid = format!("{}", app.guild_id.unwrap_or_default().0);
+        let userid = format!("{}", app.user.id.0);
+        let characters = get_character_list(&serverid, &userid).await;
+        let mut response = String::from("");
+        if characters.len() == 0 {
+            response += "You do not have any characters saved on this server!";
+        } else if app.data.options.is_empty() {
+            for i in 0..characters.len() {
+                response += format!(
+                    "{}: {} ({})\n",
+                    i + 1,
+                    characters[i].character_name.as_str(),
+                    characters[i].role.as_str()
+                )
+                .as_str();
+            }
+        } else {
+            if let Some(a) = &app.data.options.get(0).unwrap().value {
+                if let Ok(chr_num) = a.to_string().parse::<u32>() {
+                    let c = &characters[(chr_num - 1) as usize];
+                    if !set_active_character(&serverid, &userid, c.id).await {
+                        response = String::from("Error setting character!");
+                    } else {
+                        response +=
+                            format!("Set active character to {} ({})", c.character_name, c.role)
+                                .as_str()
+                    }
+                } else {
+                    let chars: Vec<&Cp2020Character> = characters
+                        .iter()
+                        .filter(|&c| c.character_name.to_lowercase() == a.to_string().to_lowercase())
+                        .collect();
+                    if chars.len() > 0 {
+                        if !set_active_character(&serverid, &userid, chars[0].id).await {
+                            response = String::from("Error setting character!");
+                        } else {
+                            response += format!(
+                                "Set active character to {} ({})",
+                                chars[0].character_name, chars[0].role
+                            )
+                            .as_str();
+                        }
+                    } else {
+                        response += format!("Unable to find saved character {}", a).as_str();
+                    }
+                }
+            }
+        }
+        if let Err(why) = app.channel_id.say(&ctx.http, response).await {
+            println!("Error sending message: {:?}", why);
+        }
+    }
+}

--- a/src/cp2020/pick_char.rs
+++ b/src/cp2020/pick_char.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use serenity::{
-    builder::CreateApplicationCommand, model::prelude::application::interaction::Interaction,
+    builder::CreateApplicationCommand, model::prelude::{application::interaction::Interaction, command::CommandOptionType},
     prelude::*,
 };
 
@@ -16,6 +16,7 @@ pub fn register(command: &mut CreateApplicationCommand) -> &mut CreateApplicatio
                 .name("character")
                 .description("name or number of character to select")
                 .required(false)
+                .kind(CommandOptionType::String)
         })
 }
 

--- a/src/cp2020/skill.rs
+++ b/src/cp2020/skill.rs
@@ -1,0 +1,85 @@
+use serenity::{
+    builder::{CreateApplicationCommand},
+    model::{
+        prelude::{
+            application::interaction::{Interaction}
+        },
+    },
+    prelude::*,
+};
+
+use crate::cp2020::common::*;
+
+pub fn register(command: &mut CreateApplicationCommand) -> &mut CreateApplicationCommand {
+    command
+        .name("skill")
+        .description("Roll a skill")
+        .create_option(|option| {
+            option
+                .name("skill")
+                .description("Which skill to roll")
+                .required(true)  
+        })
+}
+
+pub async fn run(interaction: Interaction, ctx: &Context) {
+    if let Some(app) = interaction.application_command() {
+        let serverid = format!("{}", app.guild_id.unwrap_or_default().0);
+        let userid = format!("{}", app.user.id.0);
+        let mut modifier: u32 = 0;
+    let mut response: String = String::from("");
+    if let Some(cid) = get_active_character(&serverid, &userid).await {
+        if let Some(character) = get_character(cid).await {
+            if let Some(skill) = &app.data.options.get(0).unwrap().value {
+                let c: Vec<&Cp2020Skill> = character
+                    .skills
+                    .iter()
+                    .filter(|&x| x.skill_name.to_lowercase() == skill.to_string().to_lowercase())
+                    .collect();
+
+                if c.len() > 0 {
+                    modifier += (c[0].skill_value
+                        + match c[0].skill_attribute.to_lowercase().as_str() {
+                            "inteligence" => character.inteligence,
+                            "reflex" => character.reflex,
+                            "tech" => character.tech,
+                            "cool" => character.cool,
+                            "attractiveness" => character.attractiveness,
+                            "movement" => character.movement,
+                            "body" => character.body,
+                            "empathy" => character.empathy,
+                            _ => 0,
+                        }) as u32
+                }
+                if character.role.to_lowercase() == "solo"
+                    && skill.to_string().to_lowercase() == "awareness/notice"
+                {
+                    modifier += character.special_ability as u32;
+                }
+            }
+        } else {
+            response += "__***Active character could not be loaded!***__\n"
+        }
+    } else {
+        response += "*No active character.*\n"
+    };
+
+    let result = d10_exploding();
+    response = if result == 1 {
+        format!("{}{} rolled a skill and critically failed!", response, app.user.name)
+    } else {
+        format!(
+            "{}{} rolled a skill and got {}",
+            response,
+            app.user.name,
+            result + modifier
+        )
+    };
+
+    if let Err(why) = app.channel_id.say(&ctx.http, response).await {
+        println!("Error sending message: {:?}", why);
+
+    }
+}
+}
+

--- a/src/cp2020/skill.rs
+++ b/src/cp2020/skill.rs
@@ -1,10 +1,5 @@
 use serenity::{
-    builder::{CreateApplicationCommand},
-    model::{
-        prelude::{
-            application::interaction::{Interaction}
-        },
-    },
+    builder::CreateApplicationCommand, model::prelude::application::interaction::Interaction,
     prelude::*,
 };
 
@@ -18,7 +13,7 @@ pub fn register(command: &mut CreateApplicationCommand) -> &mut CreateApplicatio
             option
                 .name("skill")
                 .description("Which skill to roll")
-                .required(true)  
+                .required(true)
         })
 }
 
@@ -27,59 +22,62 @@ pub async fn run(interaction: Interaction, ctx: &Context) {
         let serverid = format!("{}", app.guild_id.unwrap_or_default().0);
         let userid = format!("{}", app.user.id.0);
         let mut modifier: u32 = 0;
-    let mut response: String = String::from("");
-    if let Some(cid) = get_active_character(&serverid, &userid).await {
-        if let Some(character) = get_character(cid).await {
-            if let Some(skill) = &app.data.options.get(0).unwrap().value {
-                let c: Vec<&Cp2020Skill> = character
-                    .skills
-                    .iter()
-                    .filter(|&x| x.skill_name.to_lowercase() == skill.to_string().to_lowercase())
-                    .collect();
+        let mut response: String = String::from("");
+        if let Some(cid) = get_active_character(&serverid, &userid).await {
+            if let Some(character) = get_character(cid).await {
+                if let Some(skill) = &app.data.options.get(0).unwrap().value {
+                    let c: Vec<&Cp2020Skill> = character
+                        .skills
+                        .iter()
+                        .filter(|&x| {
+                            x.skill_name.to_lowercase() == skill.to_string().to_lowercase()
+                        })
+                        .collect();
 
-                if c.len() > 0 {
-                    modifier += (c[0].skill_value
-                        + match c[0].skill_attribute.to_lowercase().as_str() {
-                            "inteligence" => character.inteligence,
-                            "reflex" => character.reflex,
-                            "tech" => character.tech,
-                            "cool" => character.cool,
-                            "attractiveness" => character.attractiveness,
-                            "movement" => character.movement,
-                            "body" => character.body,
-                            "empathy" => character.empathy,
-                            _ => 0,
-                        }) as u32
+                    if c.len() > 0 {
+                        modifier += (c[0].skill_value
+                            + match c[0].skill_attribute.to_lowercase().as_str() {
+                                "inteligence" => character.inteligence,
+                                "reflex" => character.reflex,
+                                "tech" => character.tech,
+                                "cool" => character.cool,
+                                "attractiveness" => character.attractiveness,
+                                "movement" => character.movement,
+                                "body" => character.body,
+                                "empathy" => character.empathy,
+                                _ => 0,
+                            }) as u32
+                    }
+                    if character.role.to_lowercase() == "solo"
+                        && skill.to_string().to_lowercase() == "awareness/notice"
+                    {
+                        modifier += character.special_ability as u32;
+                    }
                 }
-                if character.role.to_lowercase() == "solo"
-                    && skill.to_string().to_lowercase() == "awareness/notice"
-                {
-                    modifier += character.special_ability as u32;
-                }
+            } else {
+                response += "__***Active character could not be loaded!***__\n"
             }
         } else {
-            response += "__***Active character could not be loaded!***__\n"
+            response += "*No active character.*\n"
+        };
+
+        let result = d10_exploding();
+        response = if result == 1 {
+            format!(
+                "{}{} rolled a skill and critically failed!",
+                response, app.user.name
+            )
+        } else {
+            format!(
+                "{}{} rolled a skill and got {}",
+                response,
+                app.user.name,
+                result + modifier
+            )
+        };
+
+        if let Err(why) = app.channel_id.say(&ctx.http, response).await {
+            println!("Error sending message: {:?}", why);
         }
-    } else {
-        response += "*No active character.*\n"
-    };
-
-    let result = d10_exploding();
-    response = if result == 1 {
-        format!("{}{} rolled a skill and critically failed!", response, app.user.name)
-    } else {
-        format!(
-            "{}{} rolled a skill and got {}",
-            response,
-            app.user.name,
-            result + modifier
-        )
-    };
-
-    if let Err(why) = app.channel_id.say(&ctx.http, response).await {
-        println!("Error sending message: {:?}", why);
-
     }
 }
-}
-

--- a/src/cp2020/skill.rs
+++ b/src/cp2020/skill.rs
@@ -1,5 +1,5 @@
 use serenity::{
-    builder::CreateApplicationCommand, model::prelude::application::interaction::Interaction,
+    builder::CreateApplicationCommand, model::prelude::{application::interaction::Interaction, command::CommandOptionType},
     prelude::*,
 };
 
@@ -14,6 +14,7 @@ pub fn register(command: &mut CreateApplicationCommand) -> &mut CreateApplicatio
                 .name("skill")
                 .description("Which skill to roll")
                 .required(true)
+                .kind(CommandOptionType::String)
         })
 }
 

--- a/src/cp2020_functions.rs
+++ b/src/cp2020_functions.rs
@@ -148,8 +148,6 @@ async fn cp_skill(ctx: &Context, msg: &Message, mut args: Args) -> CommandResult
 
 #[command] //need to add a way to input a character.
 async fn cp_add_char(ctx: &Context, msg: &Message, mut _args: Args) -> CommandResult {
-
-   
     let mut result = "Not yet implemented".to_string();
     while let Ok(a) = _args.single::<String>() {
         result = result + "\n" + a.as_str();
@@ -214,6 +212,27 @@ async fn cp_pick_char(ctx: &Context, msg: &Message, mut args: Args) -> CommandRe
         println!("Error sending message: {:?}", why);
     }
     Ok(())
+}
+
+async fn add_character(interaction: Interaction, ctx: &Context) {
+    let modal = interaction.application_command().unwrap()
+    .create_interaction_response(&ctx.http, |resp| {
+        resp.kind(InteractionResponseType::Modal)
+            .interaction_response_data(|response| {
+                response.custom_id("add_character");
+                response.title("");
+                response.components(|a_rows| {
+                    a_rows.create_action_row(|row| {
+                        row.create_input_text(|input| {
+                            input.custom_id("cname")
+                            .style(InputTextStyle::Short)
+                            .label("Name")
+                            .required(true)
+                        })
+                    })
+                })
+            })
+    }).await;
 }
 
 async fn get_active_character(serverid: &str, userid: &str) -> Option<i64> {

--- a/src/cp2020_functions.rs
+++ b/src/cp2020_functions.rs
@@ -215,24 +215,28 @@ async fn cp_pick_char(ctx: &Context, msg: &Message, mut args: Args) -> CommandRe
 }
 
 async fn add_character(interaction: Interaction, ctx: &Context) {
-    let modal = interaction.application_command().unwrap()
-    .create_interaction_response(&ctx.http, |resp| {
-        resp.kind(InteractionResponseType::Modal)
-            .interaction_response_data(|response| {
-                response.custom_id("add_character");
-                response.title("");
-                response.components(|a_rows| {
-                    a_rows.create_action_row(|row| {
-                        row.create_input_text(|input| {
-                            input.custom_id("cname")
-                            .style(InputTextStyle::Short)
-                            .label("Name")
-                            .required(true)
+    let modal = interaction
+        .application_command()
+        .unwrap()
+        .create_interaction_response(&ctx.http, |resp| {
+            resp.kind(InteractionResponseType::Modal)
+                .interaction_response_data(|response| {
+                    response.custom_id("add_character");
+                    response.title("");
+                    response.components(|a_rows| {
+                        a_rows.create_action_row(|row| {
+                            row.create_input_text(|input| {
+                                input
+                                    .custom_id("cname")
+                                    .style(InputTextStyle::Short)
+                                    .label("Name")
+                                    .required(true)
+                            })
                         })
                     })
                 })
-            })
-    }).await;
+        })
+        .await;
 }
 
 async fn get_active_character(serverid: &str, userid: &str) -> Option<i64> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,16 +13,66 @@ use crate::dice_commands::dice_commands::GENERAL_GROUP;
 use clap::Parser;
 use lazy_static::lazy_static;
 use serenity::{
-    async_trait, framework::standard::StandardFramework, model::gateway::Ready, prelude::*, builder::CreateApplicationCommand,
+    async_trait, framework::standard::StandardFramework, model::{gateway::Ready, id::GuildId, prelude::interaction::{Interaction, InteractionResponseType}}, prelude::*, builder::CreateApplicationCommand,
 };
 use std::sync::RwLock;
+
+lazy_static! {
+    static ref CONF: RwLock<Config> = RwLock::new(Config::new());
+}
 
 struct Handler;
 
 #[async_trait]
 impl EventHandler for Handler {
-    async fn ready(&self, _: Context, ready: Ready) {
-        println!("{:?} is connected!", ready.user.name);
+    async fn interaction_create(&self, ctx: Context, interaction: Interaction) {
+        if let Interaction::ApplicationCommand(command) = interaction {
+            println!("Received command interaction: {:#?}", command);
+
+             let content = match command.data.name.as_str() {
+                //  "add" => commands::ping::run(&command.data.options),
+                //  "id" => commands::id::run(&command.data.options),
+                //  "attachmentinput" => commands::attachmentinput::run(&command.data.options),
+                 _ => "not implemented :(".to_string(),
+             };
+
+            if let Err(why) = command
+                .create_interaction_response(&ctx.http, |response| {
+                    response
+                        .kind(InteractionResponseType::ChannelMessageWithSource)
+                        .interaction_response_data(|message| message.content(content))
+                })
+                .await
+            {
+                println!("Cannot respond to slash command: {}", why);
+            }
+        }
+    }
+
+    async fn ready(&self, ctx: Context, ready: Ready) {
+        println!("{} is connected!", ready.user.name);
+
+        let ids = CONF.read().as_deref().unwrap().get_command_guilds();
+        for id in ids {
+        let guild_id = GuildId(id.parse().expect("error parsing GuildID"));
+        let commands = GuildId::set_application_commands(&guild_id, &ctx.http, |commands| {
+            commands
+                .create_application_command(|command| cp2020::add::register(command))
+                .create_application_command(|command| cp2020::init::register(command))
+                .create_application_command(|command| cp2020::pick_char::register(command))
+                .create_application_command(|command| cp2020::skill::register(command))
+        })
+        .await;
+    
+    
+        println!("I now have the following guild slash commands: {:#?}", commands);
+    }
+        // let guild_command = Command::create_global_application_command(&ctx.http, |command| {
+        //     commands::wonderful_command::register(command)
+        // })
+        // .await;
+
+        // println!("I created the following global slash command: {:#?}", guild_command);
     }
 }
 
@@ -42,9 +92,8 @@ struct Args {
     db_url: Option<String>,
 }
 
-lazy_static! {
-    static ref CONF: RwLock<Config> = RwLock::new(Config::new());
-}
+
+
 
 #[tokio::main]
 async fn main() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,26 +26,30 @@ struct Handler;
 #[async_trait]
 impl EventHandler for Handler {
     async fn interaction_create(&self, ctx: Context, interaction: Interaction) {
-        if let Interaction::ApplicationCommand(command) = interaction {
-            println!("Received command interaction: {:#?}", command);
+        if let Interaction::ApplicationCommand(command) = interaction.clone() {
+            //println!("Received command interaction: {:#?}", command);
 
              let content = match command.data.name.as_str() {
-                //  "add" => commands::ping::run(&command.data.options),
+                  "add" => cp2020::add::run(&interaction, &ctx).await,
+                  "init" => cp2020::init::run(interaction, &ctx).await,
+                  "pick_char" => cp2020::pick_char::run(interaction, &ctx).await,
+                  "skill" => cp2020::skill::run(interaction, &ctx).await,
                 //  "id" => commands::id::run(&command.data.options),
                 //  "attachmentinput" => commands::attachmentinput::run(&command.data.options),
-                 _ => "not implemented :(".to_string(),
+                 _ => (),
              };
 
-            if let Err(why) = command
-                .create_interaction_response(&ctx.http, |response| {
-                    response
-                        .kind(InteractionResponseType::ChannelMessageWithSource)
-                        .interaction_response_data(|message| message.content(content))
-                })
-                .await
-            {
-                println!("Cannot respond to slash command: {}", why);
-            }
+            println!("{:?}", content);
+            // if let Err(why) = command
+            //     .create_interaction_response(&ctx.http, |response| {
+            //         response
+            //             .kind(InteractionResponseType::ChannelMessageWithSource)
+            //             .interaction_response_data(|message| message.content(content))
+            //     })
+            //     .await
+            // {
+            //     println!("Cannot respond to slash command: {}", why);
+            // }
         }
     }
 
@@ -65,7 +69,7 @@ impl EventHandler for Handler {
         .await;
     
     
-        println!("I now have the following guild slash commands: {:#?}", commands);
+        println!("I now have the following guild slash commands: {:#?} on guild {:?}", commands, guild_id);
     }
         // let guild_command = Command::create_global_application_command(&ctx.http, |command| {
         //     commands::wonderful_command::register(command)

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod config;
 mod cp2020_functions;
 mod dbinterface;
 mod dice_commands;
+mod cp2020;
 
 use crate::config::config::Config;
 use crate::dice_commands::dice_commands::GENERAL_GROUP;
@@ -12,7 +13,7 @@ use crate::dice_commands::dice_commands::GENERAL_GROUP;
 use clap::Parser;
 use lazy_static::lazy_static;
 use serenity::{
-    async_trait, framework::standard::StandardFramework, model::gateway::Ready, prelude::*,
+    async_trait, framework::standard::StandardFramework, model::gateway::Ready, prelude::*, builder::CreateApplicationCommand,
 };
 use std::sync::RwLock;
 
@@ -111,6 +112,7 @@ async fn main() {
     if let Err(why) = client.start().await {
         println!("Client error: {:?}", why)
     }
+
 
     cp2020_functions::cp2020_init().await;
 }


### PR DESCRIPTION
Create slash command equivalents to all of the currently implemented CP2020 game-specific commands.
Add config option to choose which guilds to enable slash commands for.